### PR TITLE
Normalize the paths to use / instead of \ on windows.

### DIFF
--- a/snapshot-proc-macro/src/lib.rs
+++ b/snapshot-proc-macro/src/lib.rs
@@ -43,9 +43,9 @@ pub fn snapshot(_: TokenStream, function: TokenStream) -> TokenStream {
             let module_path = module_path!().to_owned();
             let test_function = (#outer_fn_name).to_owned();
 
-            let snapshot = ::snapshot::Snapshot {
+            let snapshot = ::snapshot::Snapshot::new(
                 file, module_path, test_function, recorded_value,
-            };
+            );
 
             let manifest_dir = env!("CARGO_MANIFEST_DIR");
             if let Ok(_) = ::std::env::var("UPDATE_SNAPSHOTS") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ impl<T> Snapable for T where T: Debug + DeserializeOwned + Serialize {}
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct Snapshot<S: Snapable> {
-    pub file: String,
+    pub file: Vec<String>,
     pub module_path: String,
     pub test_function: String,
     pub recorded_value: S,
@@ -39,10 +39,17 @@ impl<S> Snapshot<S>
 where
     S: Snapable + Debug + DeserializeOwned + PartialEq + Serialize,
 {
-
-    pub fn new(file: String, module_path: String, test_function: String, recorded_value: S) -> Self {
+    pub fn new(
+        file: String,
+        module_path: String,
+        test_function: String,
+        recorded_value: S,
+    ) -> Self {
         Snapshot {
-            file: file.replace("\\", "/"),
+            file: Path::new(&file)
+                .components()
+                .map(|component| component.as_os_str().to_str().unwrap().to_owned())
+                .collect(),
             module_path,
             test_function,
             recorded_value,
@@ -203,17 +210,15 @@ where
     }
 
     fn path(&self, manifest_dir: &str) -> SnapFileSpec {
-        let file_path = &Path::new(&self.file);
-
-        let mut components = file_path.components();
+        let mut components = self.file.iter();
 
         // strip the filename
-        let mut filename = components.next_back().unwrap().as_os_str().to_owned();
-        filename.push(".snap");
+        let mut filename = components.next_back().unwrap().clone();
+        filename.push_str(".snap");
 
         let mut dir = PathBuf::new();
         for directory in components {
-            dir.push(directory.as_os_str());
+            dir.push(directory);
         }
 
         dir.push("__snapshots__");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,16 @@ impl<S> Snapshot<S>
 where
     S: Snapable + Debug + DeserializeOwned + PartialEq + Serialize,
 {
+
+    pub fn new(file: String, module_path: String, test_function: String, recorded_value: S) -> Self {
+        Snapshot {
+            file: file.replace("\\", "/"),
+            module_path,
+            test_function,
+            recorded_value,
+        }
+    }
+
     pub fn check_snapshot(&self, manifest_dir: &str) {
         let SnapFileSpec {
             absolute_path,

--- a/tests/__snapshots__/second.rs.snap
+++ b/tests/__snapshots__/second.rs.snap
@@ -1,6 +1,9 @@
 {
   "second::test::another_simple_snapshot": {
-    "file": "tests/second.rs",
+    "file": [
+      "tests",
+      "second.rs"
+    ],
     "module_path": "second::test",
     "test_function": "another_simple_snapshot",
     "recorded_value": 2

--- a/tests/__snapshots__/simple.rs.snap
+++ b/tests/__snapshots__/simple.rs.snap
@@ -14,5 +14,11 @@
     "module_path": "simple::test",
     "test_function": "simple_snapshot",
     "recorded_value": 1
+  },
+  "simple::test::sub_test::simple_snapshot": {
+    "file": "tests/simple.rs",
+    "module_path": "simple::test::sub_test",
+    "test_function": "simple_snapshot",
+    "recorded_value": "Nested"
   }
 }

--- a/tests/__snapshots__/simple.rs.snap
+++ b/tests/__snapshots__/simple.rs.snap
@@ -1,6 +1,9 @@
 {
   "simple::test::compound_snapshot": {
-    "file": "tests/simple.rs",
+    "file": [
+      "tests",
+      "simple.rs"
+    ],
     "module_path": "simple::test",
     "test_function": "compound_snapshot",
     "recorded_value": {
@@ -10,13 +13,19 @@
     }
   },
   "simple::test::simple_snapshot": {
-    "file": "tests/simple.rs",
+    "file": [
+      "tests",
+      "simple.rs"
+    ],
     "module_path": "simple::test",
     "test_function": "simple_snapshot",
     "recorded_value": 1
   },
   "simple::test::sub_test::simple_snapshot": {
-    "file": "tests/simple.rs",
+    "file": [
+      "tests",
+      "simple.rs"
+    ],
     "module_path": "simple::test::sub_test",
     "test_function": "simple_snapshot",
     "recorded_value": "Nested"

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -12,6 +12,16 @@ mod test {
         x
     }
 
+    #[cfg(test)]
+    mod sub_test {
+        use snapshot::snapshot;
+
+        #[snapshot]
+        fn simple_snapshot() -> String {
+            "Nested".to_owned()
+        }
+    }
+
     #[derive(Debug, Deserialize, PartialEq, Serialize)]
     struct Lol {
         a: f32,


### PR DESCRIPTION
For a test that was recorded with unix pathnames, but re-run on windows, the paths use backslashes instead of forward slashes causing an diff to occur.  

![image](https://user-images.githubusercontent.com/245622/49689217-efa6b400-fae3-11e8-9e3d-5b96877951f9.png)

This PR normalizes the paths so they're always forward slashes. 